### PR TITLE
Add a dedicated parameter for stiAddr

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ var (
 func main() {
 	listenAddr := flag.String("listenAddr", "0.0.0.0:40080", "The dhfind HTTP server listen address.")
 	dhstoreAddr := flag.String("dhstoreAddr", "", "The dhstore HTTP address.")
+	stiAddr := flag.String("stiAddr", "", "The storetheindex HTTP address, used for fetching providers.")
 	metricsAddr := flag.String("metricsAddr", "0.0.0.0:40082", "Prometheus metrics HTTP address.")
 	simulation := flag.Bool("simulation", false, "Whether dhfind runs in simulation mode.")
 	llvl := flag.String("logLevel", "info", "The logging level. Only applied if GOLOG_LOG_LEVEL environment variable is unset.")
@@ -28,8 +29,8 @@ func main() {
 		_ = logging.SetLogLevel("*", *llvl)
 	}
 
-	if *listenAddr == "" || *dhstoreAddr == "" || *metricsAddr == "" {
-		panic("listen, dhstore and metrics addresses must be provided")
+	if *listenAddr == "" || *dhstoreAddr == "" || *metricsAddr == "" || *stiAddr == "" {
+		panic("listen, dhstore, sti and metrics addresses must be provided")
 	}
 
 	m, err := metrics.New(*metricsAddr)
@@ -39,7 +40,7 @@ func main() {
 
 	ctx := context.Background()
 
-	server, err := server.New(*listenAddr, *dhstoreAddr, m, *simulation)
+	server, err := server.New(*listenAddr, *dhstoreAddr, *stiAddr, m, *simulation)
 	if err != nil {
 		panic(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	s                 *http.Server
 	m                 *metrics.Metrics
 	dhaddr            string
+	stiaddr           string
 	simulation        bool
 	simulationJobs    chan *http.Request
 	simulationCancel  context.CancelFunc
@@ -75,7 +76,7 @@ func (rec *responseWriterWithStatus) WriteHeader(code int) {
 	}
 }
 
-func New(addr, dhaddr string, m *metrics.Metrics, simulation bool) (*Server, error) {
+func New(addr, dhaddr, stiaddr string, m *metrics.Metrics, simulation bool) (*Server, error) {
 	var server Server
 
 	server.s = &http.Server{
@@ -84,6 +85,7 @@ func New(addr, dhaddr string, m *metrics.Metrics, simulation bool) (*Server, err
 	}
 	server.m = m
 	server.dhaddr = dhaddr
+	server.stiaddr = stiaddr
 	server.simulation = simulation
 	if simulation {
 		server.simulationJobs = make(chan *http.Request)
@@ -173,7 +175,7 @@ func (s *Server) handleGetMh(w lookupResponseWriter, r *http.Request) {
 	}
 	ctx := context.Background()
 
-	c, err := finderhttpclient.NewDHashClient(s.dhaddr, s.dhaddr)
+	c, err := finderhttpclient.NewDHashClient(s.dhaddr, s.stiaddr)
 	if err != nil {
 		s.handleError(w, err)
 		return


### PR DESCRIPTION
`stiAddr` needs to be different to `dhstoreAddr` as the latter is used for fetching encrypted data while the former for fetching a list of providers. These datasets are provided from different services when not deployed behind a proxy.