### PR TITLE
Skip 32 bit tests

### DIFF
--- a/.github/workflows/go-test-config.json
+++ b/.github/workflows/go-test-config.json
@@ -1,0 +1,3 @@
+{
+  "skip32bit": true
+}


### PR DESCRIPTION
Pebble is 64 bit only and dhfind depends on it through storetheindex