### PR TITLE
Handle when no multihash results are returned

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -219,8 +219,12 @@ func (s *Server) handleGetMh(w lookupResponseWriter, r *http.Request) {
 		return
 	}
 
-	// There going to be exactly one item in the array as we seached for one multihash only
-	// and if it wasn't found then an error would have been returned
+	if len(findResponse.MultihashResults) == 0 {
+		log.Errorw("No multihash results")
+		http.Error(w, "", http.StatusNotFound)
+		return
+	}
+
 	mhr := findResponse.MultihashResults[0]
 
 	for _, pr := range mhr.ProviderResults {


### PR DESCRIPTION
This can happen when there are errors that prevent any results from being returned.
See: https://github.com/ipni/go-libipni/commit/2bb518c865fa7c9cf3c2165a345f11fb5241003b