### PR TITLE
Add sharding headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ipni/go-libipni v0.0.8-0.20230502090232-d63b75b7c9d6
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/prometheus/client_golang v1.14.0
+	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.33.0
 	go.opentelemetry.io/otel/metric v0.33.0
@@ -19,6 +20,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -36,6 +38,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multicodec v0.9.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
@@ -47,6 +50,7 @@ require (
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,10 @@ github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
@@ -79,9 +81,14 @@ github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opentelemetry.io/otel v1.13.0 h1:1ZAKnNQKwBBxFtww/GwxNUyTf0AxkZzrukO8MeXqe4Y=
 go.opentelemetry.io/otel v1.13.0/go.mod h1:FH3RtdZCzRkJYFTCsAKDy9l/XYjMdNv6QrkFFB8DvVg=
@@ -146,9 +153,11 @@ google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cn
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 lukechampine.com/blake3 v1.1.7 h1:GgRMhmdsuK8+ii6UZFDL8Nb+VyMwadAgcJyfYHxG6n0=
 lukechampine.com/blake3 v1.1.7/go.mod h1:tkKEOtDkNtklkXtLNEOGNq5tcV90tJiA1vAA12R78LA=

--- a/server/server.go
+++ b/server/server.go
@@ -107,7 +107,8 @@ func New(addr, dhaddr, stiaddr string, m *metrics.Metrics, simulation bool, simu
 	server.m = m
 	server.simulation = simulation
 
-	c, err := finderhttpclient.NewDHashClient(dhaddr, stiaddr)
+	c, err := finderhttpclient.NewDHashClient(dhaddr, stiaddr,
+		finderhttpclient.WithClient(NewShardingClient()))
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -108,7 +108,7 @@ func New(addr, dhaddr, stiaddr string, m *metrics.Metrics, simulation bool, simu
 	server.simulation = simulation
 
 	c, err := finderhttpclient.NewDHashClient(dhaddr, stiaddr,
-		finderhttpclient.WithClient(NewShardingClient()))
+		finderhttpclient.WithClient(newShardingClient()))
 	if err != nil {
 		return nil, err
 	}

--- a/server/sharding_http_client.go
+++ b/server/sharding_http_client.go
@@ -2,27 +2,23 @@ package server
 
 import (
 	"net/http"
-	"path"
-
-	"github.com/multiformats/go-multihash"
+	"strings"
 )
 
 const (
 	shardKeyHeader = "x-ipni-dhstore-shard-key"
-	metadataPath   = "metadata"
-	multihashPath  = "multihash"
 )
 
-// ShardingRoundTripper adds x-ipni-dhstore-shard-key header to all GET requests for metadata and multihash.
-type ShardingRoundTripper struct {
+// shardingRoundTripper adds x-ipni-dhstore-shard-key header to all GET requests for metadata and multihash.
+type shardingRoundTripper struct {
 	http.RoundTripper
 }
 
-// NewShardingClient creates a new http.Client with ShardingRoundTripper transport. The client is designed to be used inside DHashClient for adding sharding headers to metadata and multihash lookups.
+// newShardingClient creates a new http.Client with ShardingRoundTripper transport. The client is designed to be used inside DHashClient for adding sharding headers to metadata and multihash lookups.
 // Using the client for other purposes will not make any harm but will not bring any benefits either.
-func NewShardingClient() *http.Client {
+func newShardingClient() *http.Client {
 	return &http.Client{
-		Transport: &ShardingRoundTripper{
+		Transport: &shardingRoundTripper{
 			RoundTripper: http.DefaultTransport,
 		},
 	}
@@ -33,37 +29,25 @@ func NewShardingClient() *http.Client {
 //   - If this is not a GET request - do nothing;
 //   - If the request path conforms to ".../metadata/XYZ" - then XYZ will be set as x-ipni-dhstore-shard-key header as-is;
 //   - If the request path conforms to ".../multihash/XYZ" -  the last path of the URL will be treated as B58 encoded multihash.
-func (cr *ShardingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+func (cr *shardingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	if r.Method == http.MethodGet {
-		var u, object, objectId, shardKey string
-		u = r.URL.Path
-		u, objectId = path.Split(u)
-		// the remaining url should be at least as long as "/metadata/"
-		if len(u) < len(metadataPath)+2 {
-			goto DEFAULT
-		}
-		// don't forget to remove the last "/"
-		_, object = path.Split(u[:len(u)-1])
-		switch object {
-		case metadataPath:
-			shardKey = objectId
-		case multihashPath:
-			mh, err := multihash.FromB58String(objectId)
-			if err != nil {
-				goto DEFAULT
-			}
-
-			dmh, err := multihash.Decode(mh)
-			// set the header only for double hashed lookups
-			if err == nil && dmh.Code == multihash.DBL_SHA2_256 {
-				shardKey = objectId
-			}
-		}
-
-		if len(shardKey) > 0 {
-			r.Header.Set(shardKeyHeader, shardKey)
+		const (
+			metadataPath  = "/metadata/"
+			multihashPath = "/multihash/"
+		)
+		switch {
+		case strings.HasPrefix(r.URL.Path, metadataPath):
+			r.Header.Set(shardKeyHeader, strings.TrimPrefix(r.URL.Path, metadataPath))
+		case strings.HasPrefix(r.URL.Path, multihashPath):
+			// Considering...
+			// - dhfind is only used internally
+			// - has "dh" in its name, i.e. double-hashed,
+			// - and the this roundtripper is not in the public client library anymore, i.e. moved here
+			// ...do not bother checking if suffix is a valid multihash with DBL_SHA2_256 code.
+			// Because, the chances are the lookup will not find anything anyway and
+			// the presence of shard key would make no difference.
+			r.Header.Set(shardKeyHeader, strings.TrimPrefix(r.URL.Path, multihashPath))
 		}
 	}
-DEFAULT:
 	return cr.RoundTripper.RoundTrip(r)
 }

--- a/server/sharding_http_client.go
+++ b/server/sharding_http_client.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"net/http"
+	"path"
+
+	"github.com/multiformats/go-multihash"
+)
+
+const (
+	shardKeyHeader = "x-ipni-dhstore-shard-key"
+	metadataPath   = "metadata"
+	multihashPath  = "multihash"
+)
+
+// ShardingRoundTripper adds x-ipni-dhstore-shard-key header to all GET requests for metadata and multihash.
+type ShardingRoundTripper struct {
+	http.RoundTripper
+}
+
+// NewShardingClient creates a new http.Client with ShardingRoundTripper transport. The client is designed to be used inside DHashClient for adding sharding headers to metadata and multihash lookups.
+// Using the client for other purposes will not make any harm but will not bring any benefits either.
+func NewShardingClient() *http.Client {
+	return &http.Client{
+		Transport: &ShardingRoundTripper{
+			RoundTripper: http.DefaultTransport,
+		},
+	}
+}
+
+// RoundTrip adds x-ipni-dhstore-shard-key header to all GET requests for metadata and multihash.
+// It follows the following rules:
+//   - If this is not a GET request - do nothing;
+//   - If the request path conforms to ".../metadata/XYZ" - then XYZ will be set as x-ipni-dhstore-shard-key header as-is;
+//   - If the request path conforms to ".../multihash/XYZ" -  the last path of the URL will be treated as B58 encoded multihash.
+func (cr *ShardingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.Method == http.MethodGet {
+		var u, object, objectId, shardKey string
+		u = r.URL.Path
+		u, objectId = path.Split(u)
+		// the remaining url should be at least as long as "/metadata/"
+		if len(u) < len(metadataPath)+2 {
+			goto DEFAULT
+		}
+		// don't forget to remove the last "/"
+		_, object = path.Split(u[:len(u)-1])
+		switch object {
+		case metadataPath:
+			shardKey = objectId
+		case multihashPath:
+			mh, err := multihash.FromB58String(objectId)
+			if err != nil {
+				goto DEFAULT
+			}
+
+			dmh, err := multihash.Decode(mh)
+			// set the header only for double hashed lookups
+			if err == nil && dmh.Code == multihash.DBL_SHA2_256 {
+				shardKey = objectId
+			}
+		}
+
+		if len(shardKey) > 0 {
+			r.Header.Set(shardKeyHeader, shardKey)
+		}
+	}
+DEFAULT:
+	return cr.RoundTripper.RoundTrip(r)
+}

--- a/server/sharding_http_client_test.go
+++ b/server/sharding_http_client_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardingClient(t *testing.T) {
+	var seenMultihash, seenMetadata bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := r.URL.Path
+		if r.Method != http.MethodGet {
+			require.Equal(t, "", r.Header.Get(shardKeyHeader))
+			return
+		}
+		if strings.Contains(u, "multihash/2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o") {
+			require.Equal(t, "2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", r.Header.Get(shardKeyHeader))
+			seenMultihash = true
+		} else if strings.Contains(u, "metadata") {
+			require.Equal(t, "ABCD", r.Header.Get(shardKeyHeader))
+			seenMetadata = true
+		} else {
+			require.Equal(t, "", r.Header.Get(shardKeyHeader))
+		}
+	}))
+
+	c := NewShardingClient()
+
+	sendRequest(t, c, server.URL+"/multihash/2wvrrzCXz5kN4bEKCNvZgPECjiNwdXLeHuqU5yZzeRN7j8o", http.MethodGet) // double hashed multihash
+	sendRequest(t, c, server.URL+"/multihash/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn", http.MethodGet)  // regular multihash - should be no headers
+	sendRequest(t, c, server.URL+"/multihash/INVALID", http.MethodGet)                                         // invalid multihash - should be no headers
+	sendRequest(t, c, server.URL+"/metadata/ABCD", http.MethodGet)
+	sendRequest(t, c, server.URL+"/someOtherPath/ABCD", http.MethodGet)
+	sendRequest(t, c, server.URL+"/someOtherPath/ABCD", http.MethodPost)
+	require.True(t, seenMetadata)
+	require.True(t, seenMultihash)
+}
+
+func sendRequest(t *testing.T, c *http.Client, u, method string) {
+	req, err := http.NewRequestWithContext(context.Background(), method, u, nil)
+	require.NoError(t, err)
+	_, err = c.Do(req)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds sharding headers to all requests outgoing from Double Hashed client. The integration is done by injecting a `http.Client` with a custom `RoundTripper`. No changes to the client itself were needed. 

All outgoing requests for `metadata` and `multihash` will be enhanced with the additional `x-ipni-dhstore-shard-key` header. 

The logic has been ported over from https://github.com/ipni/go-libipni/pull/38
