### PR TITLE
Encode responses as `FindResponse` not `MultihashResult`

### DIFF
--- a/server/response_writer_ipni.go
+++ b/server/response_writer_ipni.go
@@ -86,5 +86,7 @@ func (i *ipniLookupResponseWriter) Close() error {
 	if i.nd {
 		return nil
 	}
-	return i.encoder.Encode(i.result)
+	return i.encoder.Encode(model.FindResponse{
+		MultihashResults: []model.MultihashResult{i.result},
+	})
 }


### PR DESCRIPTION
When request is non-streaming, encode the outer IPNI json object